### PR TITLE
트리 컴포넌트에 insert, remove 기능 추가

### DIFF
--- a/src/HeadlessTree/Tree.tsx
+++ b/src/HeadlessTree/Tree.tsx
@@ -9,20 +9,28 @@ function TreeComponent<T extends BasicTreeItem>(
   { initialTree, options, renderItem }: TreeProps<T>,
   ref: Ref<TreeRef<T>>
 ) {
-  const { tree, open, close, toggleOpen, openAll, closeAll } = useTreeState({ initialTree, options });
+  const { tree, parentMap, childrenIndexMap, open, close, toggleOpen, openAll, closeAll, insertItem, removeItem } =
+    useTreeState({
+      initialTree,
+      options,
+    });
   const flattenedTree = useMemo(() => flattenTree(tree), [tree]);
 
   useImperativeHandle(
     ref,
     () => ({
       tree,
+      parentMap,
+      childrenIndexMap,
       open,
       close,
       toggleOpen,
       openAll,
       closeAll,
+      insertItem,
+      removeItem,
     }),
-    [tree, open, close, toggleOpen, openAll, closeAll]
+    [tree, parentMap, childrenIndexMap, insertItem, removeItem, open, close, toggleOpen, openAll, closeAll]
   );
 
   return (

--- a/src/HeadlessTree/Tree.tsx
+++ b/src/HeadlessTree/Tree.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useImperativeHandle, useMemo, type ReactElement, type Ref } from 'react';
-import { flattenTree } from './flattenTree';
+import { flattenTree } from './utils/flattenTree';
 import type { BasicTreeItem, TreeProps } from './types';
 import { useTreeState } from './useTreeState';
 

--- a/src/HeadlessTree/VirtualizedTree.tsx
+++ b/src/HeadlessTree/VirtualizedTree.tsx
@@ -16,8 +16,8 @@ export type VirtualizedTreeRef<CustomData extends BasicTreeItem> = ReturnType<ty
   virtualizer: Virtualizer<HTMLDivElement, Element>;
 };
 
-export interface VirtualizedTreeProps<CustomData extends BasicTreeItem> 
-  extends TreeProps<CustomData>, 
+export interface VirtualizedTreeProps<CustomData extends BasicTreeItem>
+  extends TreeProps<CustomData>,
     Omit<ComponentPropsWithoutRef<'div'>, 'children'> {
   /** Height of the virtualized container */
   height: number | string;
@@ -41,7 +41,11 @@ function VirtualizedTreeComponent<T extends BasicTreeItem>(
   }: VirtualizedTreeProps<T>,
   ref: Ref<VirtualizedTreeRef<T>>
 ) {
-  const { tree, open, close, toggleOpen, openAll, closeAll } = useTreeState({ initialTree, options });
+  const { tree, parentMap, childrenIndexMap, insertItem, removeItem, open, close, toggleOpen, openAll, closeAll } =
+    useTreeState({
+      initialTree,
+      options,
+    });
   const flattenedTree = useMemo(() => flattenTree(tree), [tree]);
   const parentRef = useRef<HTMLDivElement>(null);
 
@@ -56,14 +60,18 @@ function VirtualizedTreeComponent<T extends BasicTreeItem>(
     ref,
     () => ({
       tree,
+      parentMap,
+      childrenIndexMap,
       open,
       close,
       toggleOpen,
       openAll,
       closeAll,
       virtualizer,
+      insertItem,
+      removeItem,
     }),
-    [tree, open, close, toggleOpen, openAll, closeAll, virtualizer]
+    [tree, parentMap, childrenIndexMap, insertItem, removeItem, open, close, toggleOpen, openAll, closeAll, virtualizer]
   );
 
   return (

--- a/src/HeadlessTree/VirtualizedTree.tsx
+++ b/src/HeadlessTree/VirtualizedTree.tsx
@@ -8,7 +8,7 @@ import {
   type ReactElement,
   type Ref,
 } from 'react';
-import { flattenTree } from './flattenTree';
+import { flattenTree } from './utils/flattenTree';
 import type { BasicTreeItem, TreeProps } from './types';
 import { useTreeState } from './useTreeState';
 

--- a/src/HeadlessTree/index.ts
+++ b/src/HeadlessTree/index.ts
@@ -1,8 +1,9 @@
-export { flattenTree } from './flattenTree';
 export { Tree } from './Tree';
 export type { TreeRef } from './Tree';
 export type * from './types';
 export { useTreeState } from './useTreeState';
-export { getAllDescendantIds, getPath } from './utils';
+export { flattenTree } from './utils/flattenTree';
+export { getAllDescendantIds } from './utils/getAllDescendantIds';
+export { getPath } from './utils/getPath';
 export { VirtualizedTree } from './VirtualizedTree';
 export type { VirtualizedTreeProps, VirtualizedTreeRef } from './VirtualizedTree';

--- a/src/HeadlessTree/types.ts
+++ b/src/HeadlessTree/types.ts
@@ -2,6 +2,8 @@ import type { ReactNode } from 'react';
 
 export type TreeItemId = number | string;
 
+export type ParentMap = Map<TreeItemId, TreeItemId | null>;
+
 export interface BasicTreeItem<CustomData = unknown> {
   id: TreeItemId;
   /** List of child IDs for the tree item */

--- a/src/HeadlessTree/types.ts
+++ b/src/HeadlessTree/types.ts
@@ -4,6 +4,9 @@ export type TreeItemId = number | string;
 
 export type ParentMap = Map<TreeItemId, TreeItemId | null>;
 
+/** @description Map of parent ID to a map of child ID to index position */
+export type ChildrenIndexMap = Map<TreeItemId | null, Map<TreeItemId, number>>;
+
 export interface BasicTreeItem<CustomData = unknown> {
   id: TreeItemId;
   /** List of child IDs for the tree item */

--- a/src/HeadlessTree/utils/buildChildrenIndexMap.spec.ts
+++ b/src/HeadlessTree/utils/buildChildrenIndexMap.spec.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import { buildChildrenIndexMap } from './buildChildrenIndexMap';
+import type { BasicTreeItem, TreeData } from '../types';
+
+describe('buildChildrenIndexMap', () => {
+  it('should return index map for root items', () => {
+    const tree: TreeData<BasicTreeItem> = {
+      rootIds: ['1', '2', '3'],
+      items: {
+        '1': { id: '1', children: [], customData: {} },
+        '2': { id: '2', children: [], customData: {} },
+        '3': { id: '3', children: [], customData: {} },
+      },
+    };
+
+    const indexMap = buildChildrenIndexMap(tree);
+
+    const rootIndexes = indexMap.get(null);
+    expect(rootIndexes?.get('1')).toBe(0);
+    expect(rootIndexes?.get('2')).toBe(1);
+    expect(rootIndexes?.get('3')).toBe(2);
+  });
+
+  it('should return index map for child items', () => {
+    const tree: TreeData<BasicTreeItem> = {
+      rootIds: ['1'],
+      items: {
+        '1': { id: '1', children: ['2', '3', '4'], customData: {} },
+        '2': { id: '2', children: ['5'], customData: {} },
+        '3': { id: '3', children: [], customData: {} },
+        '4': { id: '4', children: [], customData: {} },
+        '5': { id: '5', children: [], customData: {} },
+      },
+    };
+
+    const indexMap = buildChildrenIndexMap(tree);
+
+    const rootIndexes = indexMap.get(null);
+    expect(rootIndexes?.get('1')).toBe(0);
+
+    const parent1Indexes = indexMap.get('1');
+    expect(parent1Indexes?.get('2')).toBe(0);
+    expect(parent1Indexes?.get('3')).toBe(1);
+    expect(parent1Indexes?.get('4')).toBe(2);
+
+    const parent2Indexes = indexMap.get('2');
+    expect(parent2Indexes?.get('5')).toBe(0);
+  });
+
+  it('should handle empty tree', () => {
+    const tree: TreeData<BasicTreeItem> = {
+      rootIds: [],
+      items: {},
+    };
+
+    const indexMap = buildChildrenIndexMap(tree);
+
+    const rootIndexes = indexMap.get(null);
+    expect(rootIndexes?.size).toBe(0);
+  });
+
+  it('should handle complex nested structure', () => {
+    const tree: TreeData<BasicTreeItem> = {
+      rootIds: ['a', 'b'],
+      items: {
+        a: { id: 'a', children: ['a1', 'a2'], customData: {} },
+        b: { id: 'b', children: ['b1'], customData: {} },
+        a1: { id: 'a1', children: ['a1-1', 'a1-2'], customData: {} },
+        a2: { id: 'a2', children: [], customData: {} },
+        b1: { id: 'b1', children: ['b1-1'], customData: {} },
+        'a1-1': { id: 'a1-1', children: [], customData: {} },
+        'a1-2': { id: 'a1-2', children: [], customData: {} },
+        'b1-1': { id: 'b1-1', children: [], customData: {} },
+      },
+    };
+
+    const indexMap = buildChildrenIndexMap(tree);
+
+    // Root level
+    const rootIndexes = indexMap.get(null);
+    expect(rootIndexes?.get('a')).toBe(0);
+    expect(rootIndexes?.get('b')).toBe(1);
+
+    // First level children
+    const parentAIndexes = indexMap.get('a');
+    expect(parentAIndexes?.get('a1')).toBe(0);
+    expect(parentAIndexes?.get('a2')).toBe(1);
+
+    const parentBIndexes = indexMap.get('b');
+    expect(parentBIndexes?.get('b1')).toBe(0);
+
+    // Second level children
+    const parentA1Indexes = indexMap.get('a1');
+    expect(parentA1Indexes?.get('a1-1')).toBe(0);
+    expect(parentA1Indexes?.get('a1-2')).toBe(1);
+
+    const parentB1Indexes = indexMap.get('b1');
+    expect(parentB1Indexes?.get('b1-1')).toBe(0);
+  });
+
+  it('should handle items with no children', () => {
+    const tree: TreeData<BasicTreeItem> = {
+      rootIds: ['1'],
+      items: {
+        '1': { id: '1', children: ['2', '3'], customData: {} },
+        '2': { id: '2', children: [], customData: {} },
+        '3': { id: '3', children: [], customData: {} },
+      },
+    };
+
+    const indexMap = buildChildrenIndexMap(tree);
+
+    const parent2Indexes = indexMap.get('2');
+    expect(parent2Indexes?.size).toBe(0);
+
+    const parent3Indexes = indexMap.get('3');
+    expect(parent3Indexes?.size).toBe(0);
+  });
+
+  it('should work with numeric IDs', () => {
+    const tree: TreeData<BasicTreeItem> = {
+      rootIds: [1, 2],
+      items: {
+        1: { id: 1, children: [3, 4], customData: {} },
+        2: { id: 2, children: [5], customData: {} },
+        3: { id: 3, children: [], customData: {} },
+        4: { id: 4, children: [], customData: {} },
+        5: { id: 5, children: [], customData: {} },
+      },
+    };
+
+    const indexMap = buildChildrenIndexMap(tree);
+
+    const rootIndexes = indexMap.get(null);
+    expect(rootIndexes?.get(1)).toBe(0);
+    expect(rootIndexes?.get(2)).toBe(1);
+
+    const parent1Indexes = indexMap.get(1);
+    expect(parent1Indexes?.get(3)).toBe(0);
+    expect(parent1Indexes?.get(4)).toBe(1);
+
+    const parent2Indexes = indexMap.get(2);
+    expect(parent2Indexes?.get(5)).toBe(0);
+  });
+
+  it('should maintain correct indexes when children have large gaps in IDs', () => {
+    const tree: TreeData<BasicTreeItem> = {
+      rootIds: ['100', '200', '300'],
+      items: {
+        '100': { id: '100', children: ['101', '105', '110'], customData: {} },
+        '200': { id: '200', children: [], customData: {} },
+        '300': { id: '300', children: [], customData: {} },
+        '101': { id: '101', children: [], customData: {} },
+        '105': { id: '105', children: [], customData: {} },
+        '110': { id: '110', children: [], customData: {} },
+      },
+    };
+
+    const indexMap = buildChildrenIndexMap(tree);
+
+    const rootIndexes = indexMap.get(null);
+    expect(rootIndexes?.get('100')).toBe(0);
+    expect(rootIndexes?.get('200')).toBe(1);
+    expect(rootIndexes?.get('300')).toBe(2);
+
+    const parent100Indexes = indexMap.get('100');
+    expect(parent100Indexes?.get('101')).toBe(0);
+    expect(parent100Indexes?.get('105')).toBe(1);
+    expect(parent100Indexes?.get('110')).toBe(2);
+  });
+});

--- a/src/HeadlessTree/utils/buildChildrenIndexMap.ts
+++ b/src/HeadlessTree/utils/buildChildrenIndexMap.ts
@@ -1,0 +1,23 @@
+import type { BasicTreeItem, ChildrenIndexMap, TreeData } from '../types';
+
+/**
+ * @description Build a children index map from a tree for O(1) index lookups
+ * @returns A map of parent IDs to a map of child IDs to their index positions
+ */
+export const buildChildrenIndexMap = <T extends BasicTreeItem>(tree: TreeData<T>): ChildrenIndexMap => {
+  const indexMap = new Map();
+
+  // Root items (parent is null)
+  const rootIndexes = new Map();
+  tree.rootIds.forEach((id, index) => rootIndexes.set(id, index));
+  indexMap.set(null, rootIndexes);
+
+  // Child items
+  Object.values(tree.items).forEach((item) => {
+    const childIndexes = new Map();
+    item.children.forEach((childId, index) => childIndexes.set(childId, index));
+    indexMap.set(item.id, childIndexes);
+  });
+
+  return indexMap;
+};

--- a/src/HeadlessTree/utils/buildParentMap.spec.ts
+++ b/src/HeadlessTree/utils/buildParentMap.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { buildParentMap } from './buildParentMap';
+import type { BasicTreeItem, TreeData } from '../types';
+
+describe('buildParentMap', () => {
+  it('should return null for root items', () => {
+    const tree: TreeData<BasicTreeItem> = {
+      rootIds: ['1', '2'],
+      items: {
+        '1': { id: '1', children: [], customData: {} },
+        '2': { id: '2', children: [], customData: {} },
+      },
+    };
+
+    const parentMap = buildParentMap(tree);
+
+    expect(parentMap.get('1')).toBe(null);
+    expect(parentMap.get('2')).toBe(null);
+  });
+
+  it('should return parent id for child items', () => {
+    const tree: TreeData<BasicTreeItem> = {
+      rootIds: ['1'],
+      items: {
+        '1': { id: '1', children: ['2', '3'], customData: {} },
+        '2': { id: '2', children: ['4'], customData: {} },
+        '3': { id: '3', children: [], customData: {} },
+        '4': { id: '4', children: [], customData: {} },
+      },
+    };
+
+    const parentMap = buildParentMap(tree);
+
+    expect(parentMap.get('1')).toBe(null);
+    expect(parentMap.get('2')).toBe('1');
+    expect(parentMap.get('3')).toBe('1');
+    expect(parentMap.get('4')).toBe('2');
+  });
+
+  it('should handle empty tree', () => {
+    const tree: TreeData<BasicTreeItem> = {
+      rootIds: [],
+      items: {},
+    };
+
+    const parentMap = buildParentMap(tree);
+
+    expect(parentMap.size).toBe(0);
+  });
+
+  it('should handle complex nested structure', () => {
+    const tree: TreeData<BasicTreeItem> = {
+      rootIds: ['a', 'b'],
+      items: {
+        a: { id: 'a', children: ['a1', 'a2'], customData: {} },
+        b: { id: 'b', children: ['b1'], customData: {} },
+        a1: { id: 'a1', children: ['a1-1', 'a1-2'], customData: {} },
+        a2: { id: 'a2', children: [], customData: {} },
+        b1: { id: 'b1', children: ['b1-1'], customData: {} },
+        'a1-1': { id: 'a1-1', children: [], customData: {} },
+        'a1-2': { id: 'a1-2', children: [], customData: {} },
+        'b1-1': { id: 'b1-1', children: [], customData: {} },
+      },
+    };
+
+    const parentMap = buildParentMap(tree);
+
+    expect(parentMap.get('a')).toBe(null);
+    expect(parentMap.get('b')).toBe(null);
+    expect(parentMap.get('a1')).toBe('a');
+    expect(parentMap.get('a2')).toBe('a');
+    expect(parentMap.get('b1')).toBe('b');
+    expect(parentMap.get('a1-1')).toBe('a1');
+    expect(parentMap.get('a1-2')).toBe('a1');
+    expect(parentMap.get('b1-1')).toBe('b1');
+  });
+
+  it('should work with numeric IDs', () => {
+    const tree: TreeData<BasicTreeItem> = {
+      rootIds: [1, 2],
+      items: {
+        1: { id: 1, children: [3, 4], customData: {} },
+        2: { id: 2, children: [5], customData: {} },
+        3: { id: 3, children: [6], customData: {} },
+        4: { id: 4, children: [], customData: {} },
+        5: { id: 5, children: [], customData: {} },
+        6: { id: 6, children: [], customData: {} },
+      },
+    };
+
+    const parentMap = buildParentMap(tree);
+
+    expect(parentMap.get(1)).toBe(null);
+    expect(parentMap.get(2)).toBe(null);
+    expect(parentMap.get(3)).toBe(1);
+    expect(parentMap.get(4)).toBe(1);
+    expect(parentMap.get(5)).toBe(2);
+    expect(parentMap.get(6)).toBe(3);
+  });
+});

--- a/src/HeadlessTree/utils/buildParentMap.ts
+++ b/src/HeadlessTree/utils/buildParentMap.ts
@@ -1,0 +1,19 @@
+import type { BasicTreeItem, ParentMap, TreeData } from '../types';
+
+/**
+ * @description Build a parent map from a tree
+ * @returns A map of parent IDs to child IDs
+ */
+export const buildParentMap = <T extends BasicTreeItem>(tree: TreeData<T>): ParentMap => {
+  const parentMap = new Map();
+
+  // Root items
+  tree.rootIds.forEach((id) => parentMap.set(id, null));
+
+  // Child items
+  Object.values(tree.items).forEach((item) => {
+    item.children.forEach((childId) => parentMap.set(childId, item.id));
+  });
+
+  return parentMap;
+};

--- a/src/HeadlessTree/utils/flattenTree.spec.ts
+++ b/src/HeadlessTree/utils/flattenTree.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { flattenTree } from './flattenTree';
-import type { BasicTreeItem, TreeData } from './types';
-import * as logModule from '../internal/logError';
+import type { BasicTreeItem, TreeData } from '../types';
+import * as logModule from '../../internal/logError';
 
 /**
  * Basic tree structure for testing:

--- a/src/HeadlessTree/utils/flattenTree.ts
+++ b/src/HeadlessTree/utils/flattenTree.ts
@@ -1,5 +1,5 @@
-import { logError } from '../internal/logError';
-import type { BasicTreeItem, TreeData, TreeItemId } from './types';
+import { logError } from '../../internal/logError';
+import type { BasicTreeItem, TreeData, TreeItemId } from '../types';
 
 interface FlattenedTreeItem<CustomData> {
   item: CustomData;

--- a/src/HeadlessTree/utils/getAllDescendantIds.spec.ts
+++ b/src/HeadlessTree/utils/getAllDescendantIds.spec.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { getAllDescendantIds } from './getAllDescendantIds';
+import type { BasicTreeItem, TreeData } from '../types';
+import * as logModule from '../../internal/logError';
+
+const createTreeItem = <T = Record<string, unknown>>(
+  id: string | number,
+  options?: Partial<BasicTreeItem<T>>
+): BasicTreeItem<T> => ({
+  id,
+  children: [],
+  isOpened: false,
+  customData: {} as T,
+  ...options,
+});
+
+/**
+ * Basic test tree structure:
+ *
+ * 1
+ * ├── 2
+ * │   ├── 4
+ * │   └── 5
+ * └── 3
+ *     └── 6
+ *         └── 7
+ */
+const createBasicTree = (): TreeData<BasicTreeItem> => ({
+  rootIds: ['1'],
+  items: {
+    '1': createTreeItem('1', { children: ['2', '3'], isOpened: true }),
+    '2': createTreeItem('2', { children: ['4', '5'], isOpened: true }),
+    '3': createTreeItem('3', { children: ['6'], isOpened: true }),
+    '4': createTreeItem('4'),
+    '5': createTreeItem('5'),
+    '6': createTreeItem('6', { children: ['7'], isOpened: true }),
+    '7': createTreeItem('7'),
+  },
+});
+
+// Mock setup for error logging tests
+let logErrorSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+beforeEach(() => {
+  logErrorSpy = vi.spyOn(logModule, 'logError').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logErrorSpy?.mockRestore();
+});
+
+describe('getAllDescendantIds', () => {
+  describe('Core functionality', () => {
+    it('should return all descendants of root node', () => {
+      const tree = createBasicTree();
+      const descendants = getAllDescendantIds(tree, '1');
+      expect(descendants).toHaveLength(6);
+      expect(descendants).toEqual(expect.arrayContaining(['2', '3', '4', '5', '6', '7']));
+    });
+
+    it('should return all descendants of intermediate node', () => {
+      const tree = createBasicTree();
+      const descendants = getAllDescendantIds(tree, '2');
+      expect(descendants).toHaveLength(2);
+      expect(descendants).toEqual(expect.arrayContaining(['4', '5']));
+    });
+
+    it('should return descendants in breadth-first order', () => {
+      const tree = createBasicTree();
+      const descendants = getAllDescendantIds(tree, '1');
+      // BFS order: level by level
+      expect(descendants).toEqual(['2', '3', '4', '5', '6', '7']);
+    });
+
+    it('should return empty array for leaf node', () => {
+      const tree = createBasicTree();
+      const descendants = getAllDescendantIds(tree, '4');
+      expect(descendants).toEqual([]);
+    });
+
+    it('should return empty array for non-existent node', () => {
+      const tree = createBasicTree();
+      const descendants = getAllDescendantIds(tree, 'non-existent');
+      expect(descendants).toEqual([]);
+    });
+
+    it('should handle single child chains', () => {
+      const tree = createBasicTree();
+      const descendants = getAllDescendantIds(tree, '3');
+      expect(descendants).toEqual(['6', '7']);
+    });
+  });
+
+  describe('Complex structures', () => {
+    it('should handle complex nested structures', () => {
+      const complexTree = {
+        rootIds: ['root'],
+        items: {
+          root: createTreeItem('root', { children: ['a', 'b', 'c'], isOpened: true }),
+          a: createTreeItem('a', { children: ['a1', 'a2'], isOpened: true }),
+          b: createTreeItem('b', { children: ['b1'], isOpened: true }),
+          c: createTreeItem('c'),
+          a1: createTreeItem('a1'),
+          a2: createTreeItem('a2', { children: ['a2-1'], isOpened: true }),
+          b1: createTreeItem('b1'),
+          'a2-1': createTreeItem('a2-1'),
+        },
+      };
+
+      const descendants = getAllDescendantIds(complexTree, 'root');
+      expect(descendants).toHaveLength(7);
+      expect(descendants).toEqual(['a', 'b', 'c', 'a1', 'a2', 'b1', 'a2-1']);
+    });
+
+    it('should handle mixed ID types', () => {
+      const mixedTree = {
+        rootIds: [1],
+        items: {
+          1: createTreeItem(1, { children: ['a', 2] }),
+          2: createTreeItem(2, { children: [3] }),
+          3: createTreeItem(3),
+          a: createTreeItem('a', { children: ['b'] }),
+          b: createTreeItem('b'),
+        },
+      };
+
+      const descendants = getAllDescendantIds(mixedTree, 1);
+      expect(descendants).toEqual(['a', 2, 'b', 3]);
+    });
+  });
+
+  describe('Edge cases and error handling', () => {
+    it('should handle malformed children references', () => {
+      const malformedTree = {
+        rootIds: ['1'],
+        items: {
+          '1': createTreeItem('1', { children: ['2', 'missing', '3'] }),
+          '2': createTreeItem('2'),
+          '3': createTreeItem('3'),
+          // 'missing' is not defined
+        },
+      };
+
+      // getAllDescendantIds includes all children in the list, regardless of validity
+      // This is the current behavior - it doesn't validate existence
+      const descendants = getAllDescendantIds(malformedTree, '1');
+      expect(descendants).toEqual(['2', 'missing', '3']);
+    });
+
+    it('should handle empty tree', () => {
+      const emptyTree = { rootIds: [], items: {} };
+      expect(getAllDescendantIds(emptyTree, 'any-id')).toEqual([]);
+    });
+  });
+});

--- a/src/HeadlessTree/utils/getAllDescendantIds.ts
+++ b/src/HeadlessTree/utils/getAllDescendantIds.ts
@@ -1,0 +1,37 @@
+import type { BasicTreeItem, TreeData, TreeItemId } from '../types';
+
+/**
+ * @description Return all descendant IDs of a specific node
+ * @returns The array of IDs of the descendants of the target node
+ * @example
+ * ```ts
+ * const tree = {
+ *   rootIds: ['1'],
+ *   items: {
+ *     '1': { id: '1', children: ['2'] },
+ *     '2': { id: '2', children: ['3'] },
+ *     '3': { id: '3', children: [] },
+ *   },
+ * };
+ * ```
+ * @returns ['2', '3']
+ */
+export const getAllDescendantIds = <CustomData extends BasicTreeItem>(
+  tree: TreeData<CustomData>,
+  id: TreeItemId
+): TreeItemId[] => {
+  const descendants: TreeItemId[] = [];
+  const queue = [...(tree.items[id]?.children || [])];
+
+  while (queue.length > 0) {
+    const currentId = queue.shift()!;
+    descendants.push(currentId);
+
+    const children = tree.items[currentId]?.children;
+    if (children) {
+      queue.push(...children);
+    }
+  }
+
+  return descendants;
+};

--- a/src/HeadlessTree/utils/getPath.spec.ts
+++ b/src/HeadlessTree/utils/getPath.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { getPath, getAllDescendantIds } from './utils';
-import type { BasicTreeItem, TreeData } from './types';
-import * as logModule from '../internal/logError';
+import { getPath } from './getPath';
+import type { BasicTreeItem, TreeData } from '../types';
+import * as logModule from '../../internal/logError';
 
 const createTreeItem = <T = Record<string, unknown>>(
   id: string | number,
@@ -14,11 +14,6 @@ const createTreeItem = <T = Record<string, unknown>>(
   ...options,
 });
 
-const createTree = <T = Record<string, unknown>>(config: {
-  rootIds: (string | number)[];
-  items: Record<string | number, BasicTreeItem<T>>;
-}): TreeData<BasicTreeItem<T>> => config;
-
 /**
  * Basic test tree structure:
  *
@@ -30,19 +25,18 @@ const createTree = <T = Record<string, unknown>>(config: {
  *     └── 6
  *         └── 7
  */
-const createBasicTree = (): TreeData<BasicTreeItem> =>
-  createTree({
-    rootIds: ['1'],
-    items: {
-      '1': createTreeItem('1', { children: ['2', '3'], isOpened: true }),
-      '2': createTreeItem('2', { children: ['4', '5'], isOpened: true }),
-      '3': createTreeItem('3', { children: ['6'], isOpened: true }),
-      '4': createTreeItem('4'),
-      '5': createTreeItem('5'),
-      '6': createTreeItem('6', { children: ['7'], isOpened: true }),
-      '7': createTreeItem('7'),
-    },
-  });
+const createBasicTree = (): TreeData<BasicTreeItem> => ({
+  rootIds: ['1'],
+  items: {
+    '1': createTreeItem('1', { children: ['2', '3'], isOpened: true }),
+    '2': createTreeItem('2', { children: ['4', '5'], isOpened: true }),
+    '3': createTreeItem('3', { children: ['6'], isOpened: true }),
+    '4': createTreeItem('4'),
+    '5': createTreeItem('5'),
+    '6': createTreeItem('6', { children: ['7'], isOpened: true }),
+    '7': createTreeItem('7'),
+  },
+});
 
 /**
  * Multi-root tree structure:
@@ -53,17 +47,16 @@ const createBasicTree = (): TreeData<BasicTreeItem> =>
  * d
  * └── e
  */
-const createMultiRootTree = (): TreeData<BasicTreeItem> =>
-  createTree({
-    rootIds: ['a', 'd'],
-    items: {
-      a: createTreeItem('a', { children: ['b'], isOpened: true }),
-      b: createTreeItem('b', { children: ['c'], isOpened: true }),
-      c: createTreeItem('c'),
-      d: createTreeItem('d', { children: ['e'], isOpened: true }),
-      e: createTreeItem('e'),
-    },
-  });
+const createMultiRootTree = (): TreeData<BasicTreeItem> => ({
+  rootIds: ['a', 'd'],
+  items: {
+    a: createTreeItem('a', { children: ['b'], isOpened: true }),
+    b: createTreeItem('b', { children: ['c'], isOpened: true }),
+    c: createTreeItem('c'),
+    d: createTreeItem('d', { children: ['e'], isOpened: true }),
+    e: createTreeItem('e'),
+  },
+});
 
 // Mock setup for error logging tests
 let logErrorSpy: ReturnType<typeof vi.spyOn> | undefined;
@@ -109,7 +102,7 @@ describe('getPath', () => {
     });
 
     it('should handle empty tree', () => {
-      const emptyTree = createTree({ rootIds: [], items: {} });
+      const emptyTree = { rootIds: [], items: {} };
       const path = getPath(emptyTree, 'any-id');
       expect(path).toEqual([]);
     });
@@ -124,28 +117,28 @@ describe('getPath', () => {
     });
 
     it('should handle mixed number and string IDs', () => {
-      const mixedTree = createTree({
+      const mixedTree = {
         rootIds: [1],
         items: {
           1: createTreeItem(1, { children: ['a', 2], isOpened: true }),
           2: createTreeItem(2),
           a: createTreeItem('a'),
         },
-      });
+      };
 
       expect(getPath(mixedTree, 'a')).toEqual([1, 'a']);
       expect(getPath(mixedTree, 2)).toEqual([1, 2]);
     });
 
     it('should find first occurrence in case of multiple paths', () => {
-      const tree = createTree({
+      const tree = {
         rootIds: ['root1', 'root2'],
         items: {
           root1: createTreeItem('root1', { children: ['shared'] }),
           root2: createTreeItem('root2', { children: ['shared'] }),
           shared: createTreeItem('shared'),
         },
-      });
+      };
 
       // The actual implementation uses DFS with stack, so it finds the last root first
       // This is expected behavior based on the current implementation
@@ -158,13 +151,13 @@ describe('getPath', () => {
 
   describe('Edge cases and error handling', () => {
     it('should handle circular references without infinite loop', () => {
-      const circularTree = createTree({
+      const circularTree = {
         rootIds: ['1'],
         items: {
           '1': createTreeItem('1', { children: ['2'] }),
           '2': createTreeItem('2', { children: ['1'] }), // Circular reference
         },
-      });
+      };
 
       // Should still find valid paths without infinite loop
       expect(getPath(circularTree, '1')).toEqual(['1']);
@@ -173,7 +166,7 @@ describe('getPath', () => {
 
     it('should skip already visited nodes in circular references', () => {
       // Create a more complex circular reference to ensure visited check is triggered
-      const complexCircularTree = createTree({
+      const complexCircularTree = {
         rootIds: ['1'],
         items: {
           '1': createTreeItem('1', { children: ['2', '3'] }),
@@ -181,7 +174,7 @@ describe('getPath', () => {
           '3': createTreeItem('3', { children: ['2'] }), // Points back to 2
           '4': createTreeItem('4', { children: ['1'] }), // Points back to root
         },
-      });
+      };
 
       // Test that we can find paths without infinite loops
       // The visited set should prevent revisiting nodes
@@ -192,13 +185,13 @@ describe('getPath', () => {
     });
 
     it('should handle self-referencing nodes', () => {
-      const selfRefTree = createTree({
+      const selfRefTree = {
         rootIds: ['1'],
         items: {
           '1': createTreeItem('1', { children: ['1', '2'] }), // Self reference
           '2': createTreeItem('2'),
         },
-      });
+      };
 
       // Should handle self-reference without infinite loop
       expect(getPath(selfRefTree, '1')).toEqual(['1']);
@@ -206,14 +199,14 @@ describe('getPath', () => {
     });
 
     it('should handle malformed tree data', () => {
-      const malformedTree = createTree({
+      const malformedTree = {
         rootIds: ['1', 'missing-root'],
         items: {
           '1': createTreeItem('1', { children: ['2', 'missing-child'] }),
           '2': createTreeItem('2'),
           // missing-root and missing-child are not defined
         },
-      });
+      };
 
       expect(getPath(malformedTree, '1')).toEqual(['1']);
       expect(getPath(malformedTree, '2')).toEqual(['1', '2']);
@@ -221,111 +214,6 @@ describe('getPath', () => {
       expect(getPath(malformedTree, 'missing-root')).toEqual(['missing-root']);
       // missing-child is referenced but not defined, current implementation finds path anyway
       expect(getPath(malformedTree, 'missing-child')).toEqual(['1', 'missing-child']);
-    });
-  });
-});
-
-describe('getAllDescendantIds', () => {
-  describe('Core functionality', () => {
-    it('should return all descendants of root node', () => {
-      const tree = createBasicTree();
-      const descendants = getAllDescendantIds(tree, '1');
-      expect(descendants).toHaveLength(6);
-      expect(descendants).toEqual(expect.arrayContaining(['2', '3', '4', '5', '6', '7']));
-    });
-
-    it('should return all descendants of intermediate node', () => {
-      const tree = createBasicTree();
-      const descendants = getAllDescendantIds(tree, '2');
-      expect(descendants).toHaveLength(2);
-      expect(descendants).toEqual(expect.arrayContaining(['4', '5']));
-    });
-
-    it('should return descendants in breadth-first order', () => {
-      const tree = createBasicTree();
-      const descendants = getAllDescendantIds(tree, '1');
-      // BFS order: level by level
-      expect(descendants).toEqual(['2', '3', '4', '5', '6', '7']);
-    });
-
-    it('should return empty array for leaf node', () => {
-      const tree = createBasicTree();
-      const descendants = getAllDescendantIds(tree, '4');
-      expect(descendants).toEqual([]);
-    });
-
-    it('should return empty array for non-existent node', () => {
-      const tree = createBasicTree();
-      const descendants = getAllDescendantIds(tree, 'non-existent');
-      expect(descendants).toEqual([]);
-    });
-
-    it('should handle single child chains', () => {
-      const tree = createBasicTree();
-      const descendants = getAllDescendantIds(tree, '3');
-      expect(descendants).toEqual(['6', '7']);
-    });
-  });
-
-  describe('Complex structures', () => {
-    it('should handle complex nested structures', () => {
-      const complexTree = createTree({
-        rootIds: ['root'],
-        items: {
-          root: createTreeItem('root', { children: ['a', 'b', 'c'], isOpened: true }),
-          a: createTreeItem('a', { children: ['a1', 'a2'], isOpened: true }),
-          b: createTreeItem('b', { children: ['b1'], isOpened: true }),
-          c: createTreeItem('c'),
-          a1: createTreeItem('a1'),
-          a2: createTreeItem('a2', { children: ['a2-1'], isOpened: true }),
-          b1: createTreeItem('b1'),
-          'a2-1': createTreeItem('a2-1'),
-        },
-      });
-
-      const descendants = getAllDescendantIds(complexTree, 'root');
-      expect(descendants).toHaveLength(7);
-      expect(descendants).toEqual(['a', 'b', 'c', 'a1', 'a2', 'b1', 'a2-1']);
-    });
-
-    it('should handle mixed ID types', () => {
-      const mixedTree = createTree({
-        rootIds: [1],
-        items: {
-          1: createTreeItem(1, { children: ['a', 2] }),
-          2: createTreeItem(2, { children: [3] }),
-          3: createTreeItem(3),
-          a: createTreeItem('a', { children: ['b'] }),
-          b: createTreeItem('b'),
-        },
-      });
-
-      const descendants = getAllDescendantIds(mixedTree, 1);
-      expect(descendants).toEqual(['a', 2, 'b', 3]);
-    });
-  });
-
-  describe('Edge cases and error handling', () => {
-    it('should handle malformed children references', () => {
-      const malformedTree = createTree({
-        rootIds: ['1'],
-        items: {
-          '1': createTreeItem('1', { children: ['2', 'missing', '3'] }),
-          '2': createTreeItem('2'),
-          '3': createTreeItem('3'),
-          // 'missing' is not defined
-        },
-      });
-
-      // getAllDescendantIds includes all children in the list, regardless of validity
-      // This is the current behavior - it doesn't validate existence
-      const descendants = getAllDescendantIds(malformedTree, '1');
-      expect(descendants).toEqual(['2', 'missing', '3']);
-    });
-
-    it('should handle empty tree', () => {
-      const emptyTree = createTree({ rootIds: [], items: {} });
-      expect(getAllDescendantIds(emptyTree, 'any-id')).toEqual([]);
     });
   });
 });

--- a/src/HeadlessTree/utils/getPath.ts
+++ b/src/HeadlessTree/utils/getPath.ts
@@ -1,4 +1,4 @@
-import type { BasicTreeItem, TreeData, TreeItemId } from './types';
+import type { BasicTreeItem, TreeData, TreeItemId } from '../types';
 
 /**
  * @description Find the path to a specific node in the tree using iterative DFS
@@ -16,7 +16,10 @@ import type { BasicTreeItem, TreeData, TreeItemId } from './types';
  * ```
  * @returns ['1', '2', '3']
  */
-export const getPath = <T extends BasicTreeItem>(tree: TreeData<T>, targetId: TreeItemId): TreeItemId[] => {
+export const getPath = <CustomData extends BasicTreeItem>(
+  tree: TreeData<CustomData>,
+  targetId: TreeItemId
+): TreeItemId[] => {
   // Stack to store [nodeId, pathToNode] pairs
   const stack: Array<[TreeItemId, TreeItemId[]]> = [];
 
@@ -55,37 +58,4 @@ export const getPath = <T extends BasicTreeItem>(tree: TreeData<T>, targetId: Tr
 
   // Node not found
   return [];
-};
-
-/**
- * @description Return all descendant IDs of a specific node
- * @returns The array of IDs of the descendants of the target node
- * @example
- * ```ts
- * const tree = {
- *   rootIds: ['1'],
- *   items: {
- *     '1': { id: '1', children: ['2'] },
- *     '2': { id: '2', children: ['3'] },
- *     '3': { id: '3', children: [] },
- *   },
- * };
- * ```
- * @returns ['2', '3']
- */
-export const getAllDescendantIds = <T extends BasicTreeItem>(tree: TreeData<T>, id: TreeItemId): TreeItemId[] => {
-  const descendants: TreeItemId[] = [];
-  const queue = [...(tree.items[id]?.children || [])];
-
-  while (queue.length > 0) {
-    const currentId = queue.shift()!;
-    descendants.push(currentId);
-
-    const children = tree.items[currentId]?.children;
-    if (children) {
-      queue.push(...children);
-    }
-  }
-
-  return descendants;
 };

--- a/src/HeadlessTree/utils/insertTreeItem.spec.ts
+++ b/src/HeadlessTree/utils/insertTreeItem.spec.ts
@@ -1,0 +1,491 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { insertTreeItem, insertIdIntoArray } from './insertTreeItem';
+import type { BasicTreeItem, TreeData } from '../types';
+import * as logModule from '../../internal/logError';
+
+const createTreeItem = <T = Record<string, unknown>>(
+  id: string | number,
+  options?: Partial<BasicTreeItem<T>>
+): BasicTreeItem<T> => ({
+  id,
+  children: [],
+  isOpened: false,
+  customData: {} as T,
+  ...options,
+});
+
+/**
+ * Basic test tree structure:
+ *
+ * 1
+ * ├── 2
+ * │   ├── 4
+ * │   └── 5
+ * └── 3
+ *     └── 6
+ *         └── 7
+ */
+const createBasicTree = (): TreeData<BasicTreeItem> => ({
+  rootIds: ['1'],
+  items: {
+    '1': createTreeItem('1', { children: ['2', '3'], isOpened: true }),
+    '2': createTreeItem('2', { children: ['4', '5'], isOpened: true }),
+    '3': createTreeItem('3', { children: ['6'], isOpened: true }),
+    '4': createTreeItem('4'),
+    '5': createTreeItem('5'),
+    '6': createTreeItem('6', { children: ['7'], isOpened: true }),
+    '7': createTreeItem('7'),
+  },
+});
+
+/**
+ * Multi-root tree structure:
+ *
+ * a
+ * └── b
+ *     └── c
+ * d
+ * └── e
+ */
+const createMultiRootTree = (): TreeData<BasicTreeItem> => ({
+  rootIds: ['a', 'd'],
+  items: {
+    a: createTreeItem('a', { children: ['b'], isOpened: true }),
+    b: createTreeItem('b', { children: ['c'], isOpened: true }),
+    c: createTreeItem('c'),
+    d: createTreeItem('d', { children: ['e'], isOpened: true }),
+    e: createTreeItem('e'),
+  },
+});
+
+// Mock setup for error logging tests
+let logErrorSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+beforeEach(() => {
+  logErrorSpy = vi.spyOn(logModule, 'logError').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logErrorSpy?.mockRestore();
+});
+
+describe('insertIdIntoArray', () => {
+  const newItem = createTreeItem('new-item');
+  const treeItemIds = ['1', '2', '3'];
+
+  describe('Position-based insertion', () => {
+    it('should insert at first position', () => {
+      const result = insertIdIntoArray({
+        position: 'first',
+        treeItemIds,
+        newItem,
+      });
+      expect(result).toEqual(['new-item', '1', '2', '3']);
+    });
+
+    it('should insert at last position', () => {
+      const result = insertIdIntoArray({
+        position: 'last',
+        treeItemIds,
+        newItem,
+      });
+      expect(result).toEqual(['1', '2', '3', 'new-item']);
+    });
+
+    it('should insert at specific numeric position', () => {
+      const result = insertIdIntoArray({
+        position: 1,
+        treeItemIds,
+        newItem,
+      });
+      expect(result).toEqual(['1', 'new-item', '2', '3']);
+    });
+
+    it('should insert at position 0', () => {
+      const result = insertIdIntoArray({
+        position: 0,
+        treeItemIds,
+        newItem,
+      });
+      expect(result).toEqual(['new-item', '1', '2', '3']);
+    });
+
+    it('should insert at the end when position equals length', () => {
+      const result = insertIdIntoArray({
+        position: 3,
+        treeItemIds,
+        newItem,
+      });
+      expect(result).toEqual(['1', '2', '3', 'new-item']);
+    });
+  });
+
+  describe('Relative insertion', () => {
+    it('should insert before specified item', () => {
+      const result = insertIdIntoArray({
+        position: { before: '2' },
+        treeItemIds,
+        newItem,
+      });
+      expect(result).toEqual(['1', 'new-item', '2', '3']);
+    });
+
+    it('should insert after specified item', () => {
+      const result = insertIdIntoArray({
+        position: { after: '2' },
+        treeItemIds,
+        newItem,
+      });
+      expect(result).toEqual(['1', '2', 'new-item', '3']);
+    });
+
+    it('should insert before first item', () => {
+      const result = insertIdIntoArray({
+        position: { before: '1' },
+        treeItemIds,
+        newItem,
+      });
+      expect(result).toEqual(['new-item', '1', '2', '3']);
+    });
+
+    it('should insert after last item', () => {
+      const result = insertIdIntoArray({
+        position: { after: '3' },
+        treeItemIds,
+        newItem,
+      });
+      expect(result).toEqual(['1', '2', '3', 'new-item']);
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should log error for invalid before position', () => {
+      const result = insertIdIntoArray({
+        position: { before: 'non-existent' },
+        treeItemIds,
+        newItem,
+      });
+
+      expect(logErrorSpy).toHaveBeenCalledOnce();
+      expect(result).toEqual(['1', '2', '3']); // Return original array
+    });
+
+    it('should log error for invalid after position', () => {
+      const result = insertIdIntoArray({
+        position: { after: 'non-existent' },
+        treeItemIds,
+        newItem,
+      });
+
+      expect(logErrorSpy).toHaveBeenCalledOnce();
+      expect(result).toEqual(['1', '2', '3']); // Return original array
+    });
+
+    it('should log error for out of bounds position (negative)', () => {
+      const result = insertIdIntoArray({
+        position: -1,
+        treeItemIds,
+        newItem,
+      });
+
+      expect(logErrorSpy).toHaveBeenCalledOnce();
+      expect(result).toEqual(['1', '2', '3']); // Return original array
+    });
+
+    it('should log error for out of bounds position (too large)', () => {
+      const result = insertIdIntoArray({
+        position: 4,
+        treeItemIds,
+        newItem,
+      });
+
+      expect(logErrorSpy).toHaveBeenCalledOnce();
+      expect(result).toEqual(['1', '2', '3']); // Return original array
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle empty array', () => {
+      const result = insertIdIntoArray({
+        position: 'first',
+        treeItemIds: [],
+        newItem,
+      });
+      expect(result).toEqual(['new-item']);
+    });
+  });
+});
+
+describe('insertTreeItem', () => {
+  describe('Root insertion', () => {
+    it('should insert new item at root level - first position', () => {
+      const tree = createBasicTree();
+      const newItem = createTreeItem('new-root');
+
+      const result = insertTreeItem({
+        tree,
+        parentId: null,
+        newItem,
+        position: 'first',
+      });
+
+      expect(result.rootIds).toEqual(['new-root', '1']);
+      expect(result.items['new-root']).toEqual(newItem);
+      expect(result.items['1']).toEqual(tree.items['1']); // Original items unchanged
+    });
+
+    it('should insert new item at root level - last position', () => {
+      const tree = createMultiRootTree();
+      const newItem = createTreeItem('new-root');
+
+      const result = insertTreeItem({
+        tree,
+        parentId: null,
+        newItem,
+        position: 'last',
+      });
+
+      expect(result.rootIds).toEqual(['a', 'd', 'new-root']);
+      expect(result.items['new-root']).toEqual(newItem);
+    });
+
+    it('should insert new item at root level - specific position', () => {
+      const tree = createMultiRootTree();
+      const newItem = createTreeItem('new-root');
+
+      const result = insertTreeItem({
+        tree,
+        parentId: null,
+        newItem,
+        position: 1,
+      });
+
+      expect(result.rootIds).toEqual(['a', 'new-root', 'd']);
+      expect(result.items['new-root']).toEqual(newItem);
+    });
+  });
+
+  describe('Child insertion', () => {
+    it('should insert new child at first position', () => {
+      const tree = createBasicTree();
+      const newItem = createTreeItem('new-child');
+
+      const result = insertTreeItem({
+        tree,
+        parentId: '2',
+        newItem,
+        position: 'first',
+      });
+
+      expect(result.items['2'].children).toEqual(['new-child', '4', '5']);
+      expect(result.items['new-child']).toEqual(newItem);
+      expect(result.rootIds).toEqual(tree.rootIds); // Root unchanged
+    });
+
+    it('should insert new child at last position', () => {
+      const tree = createBasicTree();
+      const newItem = createTreeItem('new-child');
+
+      const result = insertTreeItem({
+        tree,
+        parentId: '2',
+        newItem,
+        position: 'last',
+      });
+
+      expect(result.items['2'].children).toEqual(['4', '5', 'new-child']);
+      expect(result.items['new-child']).toEqual(newItem);
+    });
+
+    it('should insert new child before existing child', () => {
+      const tree = createBasicTree();
+      const newItem = createTreeItem('new-child');
+
+      const result = insertTreeItem({
+        tree,
+        parentId: '2',
+        newItem,
+        position: { before: '5' },
+      });
+
+      expect(result.items['2'].children).toEqual(['4', 'new-child', '5']);
+      expect(result.items['new-child']).toEqual(newItem);
+    });
+
+    it('should insert new child after existing child', () => {
+      const tree = createBasicTree();
+      const newItem = createTreeItem('new-child');
+
+      const result = insertTreeItem({
+        tree,
+        parentId: '2',
+        newItem,
+        position: { after: '4' },
+      });
+
+      expect(result.items['2'].children).toEqual(['4', 'new-child', '5']);
+      expect(result.items['new-child']).toEqual(newItem);
+    });
+
+    it('should insert new child to leaf node', () => {
+      const tree = createBasicTree();
+      const newItem = createTreeItem('new-child');
+
+      const result = insertTreeItem({
+        tree,
+        parentId: '7',
+        newItem,
+        position: 'first',
+      });
+
+      expect(result.items['7'].children).toEqual(['new-child']);
+      expect(result.items['new-child']).toEqual(newItem);
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should log error for non-existent parent', () => {
+      const tree = createBasicTree();
+      const newItem = createTreeItem('new-child');
+
+      const result = insertTreeItem({
+        tree,
+        parentId: 'non-existent',
+        newItem,
+        position: 'first',
+      });
+
+      expect(logErrorSpy).toHaveBeenCalledOnce();
+      // Should return original tree unchanged
+      expect(result).toEqual(tree);
+      expect(result.items['new-child']).toBeUndefined();
+    });
+
+    it('should handle invalid position in child insertion', () => {
+      const tree = createBasicTree();
+      const newItem = createTreeItem('new-child');
+
+      const result = insertTreeItem({
+        tree,
+        parentId: '2',
+        newItem,
+        position: { before: 'non-existent' },
+      });
+
+      expect(logErrorSpy).toHaveBeenCalled();
+      // Should return original tree when child position is invalid
+      expect(result.items['2'].children).toEqual(['4', '5']); // Unchanged
+    });
+  });
+
+  describe('Data integrity', () => {
+    it('should not mutate original tree', () => {
+      const tree = createBasicTree();
+      const originalRootIds = [...tree.rootIds];
+      const originalItems = { ...tree.items };
+      const newItem = createTreeItem('new-child');
+
+      insertTreeItem({
+        tree,
+        parentId: '2',
+        newItem,
+        position: 'first',
+      });
+
+      expect(tree.rootIds).toEqual(originalRootIds);
+      expect(tree.items).toEqual(originalItems);
+    });
+
+    it('should preserve all original items and properties', () => {
+      const tree = createBasicTree();
+      const newItem = createTreeItem('new-child');
+
+      const result = insertTreeItem({
+        tree,
+        parentId: '1',
+        newItem,
+        position: 'last',
+      });
+
+      // All original items should be preserved
+      Object.keys(tree.items).forEach((key) => {
+        if (key !== '1') {
+          expect(result.items[key]).toEqual(tree.items[key]);
+        }
+      });
+
+      // Modified parent should have new children array but same other properties
+      expect(result.items['1'].id).toBe(tree.items['1'].id);
+      expect(result.items['1'].isOpened).toBe(tree.items['1'].isOpened);
+      expect(result.items['1'].customData).toBe(tree.items['1'].customData);
+    });
+  });
+
+  describe('Mixed types and complex scenarios', () => {
+    it('should handle mixed number and string IDs', () => {
+      const mixedTree = {
+        rootIds: [1],
+        items: {
+          1: createTreeItem(1, { children: ['a', 2], isOpened: true }),
+          2: createTreeItem(2),
+          a: createTreeItem('a'),
+        },
+      };
+      const newItem = createTreeItem('new-mixed');
+
+      const result = insertTreeItem({
+        tree: mixedTree,
+        parentId: 1,
+        newItem,
+        position: { after: 'a' },
+      });
+
+      expect(result.items[1].children).toEqual(['a', 'new-mixed', 2]);
+    });
+
+    it('should handle empty tree insertion at root', () => {
+      const emptyTree = { rootIds: [], items: {} };
+      const newItem = createTreeItem('first-item');
+
+      const result = insertTreeItem({
+        tree: emptyTree,
+        parentId: null,
+        newItem,
+        position: 'first',
+      });
+
+      expect(result.rootIds).toEqual(['first-item']);
+      expect(result.items['first-item']).toEqual(newItem);
+    });
+
+    it('should handle complex tree with custom data', () => {
+      type CustomData = { label: string; value: number };
+      const customTree: TreeData<BasicTreeItem<CustomData>> = {
+        rootIds: ['root'],
+        items: {
+          root: createTreeItem('root', {
+            children: ['child1'],
+            customData: { label: 'Root', value: 0 },
+          }),
+          child1: createTreeItem('child1', {
+            customData: { label: 'Child 1', value: 1 },
+          }),
+        },
+      };
+
+      const newItem = createTreeItem('new-custom', {
+        customData: { label: 'New Item', value: 99 },
+      });
+
+      const result = insertTreeItem({
+        tree: customTree,
+        parentId: 'root',
+        newItem,
+        position: 'last',
+      });
+
+      expect(result.items['root'].children).toEqual(['child1', 'new-custom']);
+      expect(result.items['new-custom'].customData).toEqual({ label: 'New Item', value: 99 });
+    });
+  });
+});

--- a/src/HeadlessTree/utils/insertTreeItem.ts
+++ b/src/HeadlessTree/utils/insertTreeItem.ts
@@ -1,0 +1,84 @@
+import { logError } from '../../internal/logError';
+import type { BasicTreeItem, TreeData, TreeItemId } from '../types';
+
+type InsertPosition =
+  | number // Index-based insertion (0 = first position, 1 = second position, etc.)
+  | 'first' // Insert at the beginning of children array
+  | 'last' // Insert at the end of children array
+  | { before: TreeItemId } // Insert before the specified item ID
+  | { after: TreeItemId }; // Insert after the specified item ID
+
+export const insertIdIntoArray = ({
+  position,
+  treeItemIds,
+  newItem,
+}: {
+  position: InsertPosition;
+  treeItemIds: TreeItemId[];
+  newItem: BasicTreeItem;
+}): TreeItemId[] => {
+  const result = [...treeItemIds];
+  if (position === 'first') {
+    result.unshift(newItem.id);
+    return result;
+  }
+  if (position === 'last') {
+    result.push(newItem.id);
+    return result;
+  }
+  if (typeof position === 'object' && 'before' in position) {
+    const index = result.indexOf(position.before);
+    if (index === -1) {
+      logError(new Error(`[insertTreeItem] Item with id "${position.before}" not found in the tree`));
+      return result;
+    }
+    result.splice(index, 0, newItem.id);
+    return result;
+  }
+  if (typeof position === 'object' && 'after' in position) {
+    const index = result.indexOf(position.after);
+    if (index === -1) {
+      logError(new Error(`[insertTreeItem] Item with id "${position.after}" not found in the tree`));
+      return result;
+    }
+    result.splice(index + 1, 0, newItem.id);
+    return result;
+  }
+  if (position < 0 || position > result.length) {
+    logError(new Error(`[insertTreeItem] Position ${position} is out of bounds (0-${result.length})`));
+    return result;
+  }
+  // position: number
+  result.splice(position, 0, newItem.id);
+  return result;
+};
+
+/** @description Insert a new item into the tree */
+export const insertTreeItem = <T extends BasicTreeItem>({
+  tree,
+  parentId,
+  newItem,
+  position,
+}: {
+  tree: TreeData<T>;
+  parentId: TreeItemId | null;
+  newItem: T;
+  position: InsertPosition;
+}): TreeData<T> => {
+  const newRootIds = [...tree.rootIds];
+  const newTreeItems = { ...tree.items, [newItem.id]: newItem };
+
+  // NOTE: Add to root
+  if (parentId === null) {
+    return { rootIds: insertIdIntoArray({ position, treeItemIds: newRootIds, newItem }), items: newTreeItems };
+  }
+
+  if (!newTreeItems[parentId]) {
+    logError(new Error(`[insertTreeItem] Parent item with id "${parentId}" not found in the tree`));
+    return tree;
+  }
+
+  const newChildren = insertIdIntoArray({ position, treeItemIds: newTreeItems[parentId].children, newItem });
+  newTreeItems[parentId] = { ...newTreeItems[parentId], children: newChildren };
+  return { rootIds: newRootIds, items: newTreeItems };
+};

--- a/src/HeadlessTree/utils/removeTreeItem.spec.ts
+++ b/src/HeadlessTree/utils/removeTreeItem.spec.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { removeTreeItem } from './removeTreeItem';
+import type { BasicTreeItem, TreeData } from '../types';
+import * as logModule from '../../internal/logError';
+import { buildParentMap } from './buildParentMap';
+
+const createTreeItem = <T = Record<string, unknown>>(
+  id: string | number,
+  options?: Partial<BasicTreeItem<T>>
+): BasicTreeItem<T> => ({
+  id,
+  children: [],
+  isOpened: false,
+  customData: {} as T,
+  ...options,
+});
+
+/**
+ * Basic test tree structure:
+ *
+ * 1
+ * ├── 2
+ * │   ├── 4
+ * │   └── 5
+ * └── 3
+ *     └── 6
+ *         └── 7
+ */
+const createBasicTree = (): TreeData<BasicTreeItem> => ({
+  rootIds: ['1'],
+  items: {
+    '1': createTreeItem('1', { children: ['2', '3'], isOpened: true }),
+    '2': createTreeItem('2', { children: ['4', '5'], isOpened: true }),
+    '3': createTreeItem('3', { children: ['6'], isOpened: true }),
+    '4': createTreeItem('4'),
+    '5': createTreeItem('5'),
+    '6': createTreeItem('6', { children: ['7'], isOpened: true }),
+    '7': createTreeItem('7'),
+  },
+});
+
+/**
+ * Multi-root tree structure:
+ *
+ * a
+ * └── b
+ *     └── c
+ * d
+ * └── e
+ */
+const createMultiRootTree = (): TreeData<BasicTreeItem> => ({
+  rootIds: ['a', 'd'],
+  items: {
+    a: createTreeItem('a', { children: ['b'], isOpened: true }),
+    b: createTreeItem('b', { children: ['c'], isOpened: true }),
+    c: createTreeItem('c'),
+    d: createTreeItem('d', { children: ['e'], isOpened: true }),
+    e: createTreeItem('e'),
+  },
+});
+
+// Mock setup for error logging tests
+let logErrorSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+beforeEach(() => {
+  logErrorSpy = vi.spyOn(logModule, 'logError').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logErrorSpy?.mockRestore();
+});
+
+describe('removeTreeItem', () => {
+  describe('Leaf node removal', () => {
+    it('should remove a leaf node', () => {
+      const tree = createBasicTree();
+      const parentMap = buildParentMap(tree);
+
+      const result = removeTreeItem({
+        tree,
+        itemId: '4',
+        parentMap,
+      });
+
+      expect(result.items['4']).toBeUndefined();
+      expect(result.items['2'].children).toEqual(['5']);
+      expect(Object.keys(result.items)).toHaveLength(6); // 7 - 1
+    });
+
+    it('should remove the only child from parent', () => {
+      const tree = createBasicTree();
+      const parentMap = buildParentMap(tree);
+
+      const result = removeTreeItem({
+        tree,
+        itemId: '7',
+        parentMap,
+      });
+
+      expect(result.items['7']).toBeUndefined();
+      expect(result.items['6'].children).toEqual([]);
+      expect(Object.keys(result.items)).toHaveLength(6);
+    });
+  });
+
+  describe('Node with descendants removal', () => {
+    it('should remove a node and all its descendants', () => {
+      const tree = createBasicTree();
+      const parentMap = buildParentMap(tree);
+
+      const result = removeTreeItem({
+        tree,
+        itemId: '2',
+        parentMap,
+      });
+
+      // '2', '4', '5' should be removed
+      expect(result.items['2']).toBeUndefined();
+      expect(result.items['4']).toBeUndefined();
+      expect(result.items['5']).toBeUndefined();
+      expect(result.items['1'].children).toEqual(['3']);
+      expect(Object.keys(result.items)).toHaveLength(4); // 7 - 3
+    });
+
+    it('should remove deeply nested descendants', () => {
+      const tree = createBasicTree();
+      const parentMap = buildParentMap(tree);
+
+      const result = removeTreeItem({
+        tree,
+        itemId: '3',
+        parentMap,
+      });
+
+      // '3', '6', '7' should be removed
+      expect(result.items['3']).toBeUndefined();
+      expect(result.items['6']).toBeUndefined();
+      expect(result.items['7']).toBeUndefined();
+      expect(result.items['1'].children).toEqual(['2']);
+      expect(Object.keys(result.items)).toHaveLength(4); // 7 - 3
+    });
+  });
+
+  describe('Root node removal', () => {
+    it('should remove a root node and all its descendants', () => {
+      const tree = createBasicTree();
+      const parentMap = buildParentMap(tree);
+
+      const result = removeTreeItem({
+        tree,
+        itemId: '1',
+        parentMap,
+      });
+
+      // All items should be removed
+      expect(result.rootIds).toEqual([]);
+      expect(Object.keys(result.items)).toHaveLength(0);
+    });
+
+    it('should remove one root from multi-root tree', () => {
+      const tree = createMultiRootTree();
+      const parentMap = buildParentMap(tree);
+
+      const result = removeTreeItem({
+        tree,
+        itemId: 'a',
+        parentMap,
+      });
+
+      // 'a', 'b', 'c' should be removed
+      expect(result.rootIds).toEqual(['d']);
+      expect(result.items['a']).toBeUndefined();
+      expect(result.items['b']).toBeUndefined();
+      expect(result.items['c']).toBeUndefined();
+      expect(result.items['d']).toBeDefined();
+      expect(result.items['e']).toBeDefined();
+      expect(Object.keys(result.items)).toHaveLength(2);
+    });
+
+    it('should handle removing last root item', () => {
+      const tree = createMultiRootTree();
+      const parentMap = buildParentMap(tree);
+
+      const result = removeTreeItem({
+        tree,
+        itemId: 'd',
+        parentMap,
+      });
+
+      expect(result.rootIds).toEqual(['a']);
+      expect(result.items['d']).toBeUndefined();
+      expect(result.items['e']).toBeUndefined();
+      expect(Object.keys(result.items)).toHaveLength(3); // a, b, c
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should log error for non-existent item', () => {
+      const tree = createBasicTree();
+      const parentMap = buildParentMap(tree);
+
+      const result = removeTreeItem({
+        tree,
+        itemId: 'non-existent',
+        parentMap,
+      });
+
+      expect(logErrorSpy).toHaveBeenCalledOnce();
+      expect(result).toEqual(tree); // Return original tree unchanged
+    });
+  });
+
+  describe('Data integrity', () => {
+    it('should not mutate original tree', () => {
+      const tree = createBasicTree();
+      const parentMap = buildParentMap(tree);
+      const originalRootIds = [...tree.rootIds];
+      const originalItems = { ...tree.items };
+
+      removeTreeItem({
+        tree,
+        itemId: '2',
+        parentMap,
+      });
+
+      expect(tree.rootIds).toEqual(originalRootIds);
+      expect(tree.items).toEqual(originalItems);
+    });
+
+    it('should preserve unaffected items', () => {
+      const tree = createBasicTree();
+      const parentMap = buildParentMap(tree);
+
+      const result = removeTreeItem({
+        tree,
+        itemId: '2',
+        parentMap,
+      });
+
+      // Items '3', '6', '7' should remain unchanged
+      expect(result.items['3']).toEqual(tree.items['3']);
+      expect(result.items['6']).toEqual(tree.items['6']);
+      expect(result.items['7']).toEqual(tree.items['7']);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle single item tree', () => {
+      const tree: TreeData<BasicTreeItem> = {
+        rootIds: ['only'],
+        items: {
+          only: createTreeItem('only'),
+        },
+      };
+      const parentMap = buildParentMap(tree);
+
+      const result = removeTreeItem({
+        tree,
+        itemId: 'only',
+        parentMap,
+      });
+
+      expect(result.rootIds).toEqual([]);
+      expect(Object.keys(result.items)).toHaveLength(0);
+    });
+
+    it('should handle numeric IDs', () => {
+      const tree: TreeData<BasicTreeItem> = {
+        rootIds: [1],
+        items: {
+          1: createTreeItem(1, { children: [2, 3] }),
+          2: createTreeItem(2),
+          3: createTreeItem(3),
+        },
+      };
+      const parentMap = buildParentMap(tree);
+
+      const result = removeTreeItem({
+        tree,
+        itemId: 2,
+        parentMap,
+      });
+
+      expect(result.items[2]).toBeUndefined();
+      expect(result.items[1].children).toEqual([3]);
+    });
+
+    it('should handle complex nested removal', () => {
+      const tree = createBasicTree();
+      const parentMap = buildParentMap(tree);
+
+      // Remove node with grandchildren
+      const result = removeTreeItem({
+        tree,
+        itemId: '6',
+        parentMap,
+      });
+
+      expect(result.items['6']).toBeUndefined();
+      expect(result.items['7']).toBeUndefined();
+      expect(result.items['3'].children).toEqual([]);
+      expect(Object.keys(result.items)).toHaveLength(5); // 7 - 2
+    });
+  });
+
+  describe('Custom data preservation', () => {
+    it('should preserve custom data in remaining items', () => {
+      type CustomData = { label: string; value: number };
+      const customTree: TreeData<BasicTreeItem<CustomData>> = {
+        rootIds: ['root'],
+        items: {
+          root: createTreeItem('root', {
+            children: ['child1', 'child2'],
+            customData: { label: 'Root', value: 0 },
+          }),
+          child1: createTreeItem('child1', {
+            customData: { label: 'Child 1', value: 1 },
+          }),
+          child2: createTreeItem('child2', {
+            customData: { label: 'Child 2', value: 2 },
+          }),
+        },
+      };
+      const parentMap = buildParentMap(customTree);
+
+      const result = removeTreeItem({
+        tree: customTree,
+        itemId: 'child1',
+        parentMap,
+      });
+
+      expect(result.items['child1']).toBeUndefined();
+      expect(result.items['root'].customData).toEqual({ label: 'Root', value: 0 });
+      expect(result.items['child2'].customData).toEqual({ label: 'Child 2', value: 2 });
+    });
+  });
+});

--- a/src/HeadlessTree/utils/removeTreeItem.ts
+++ b/src/HeadlessTree/utils/removeTreeItem.ts
@@ -1,0 +1,102 @@
+import { logError } from '../../internal/logError';
+import type { BasicTreeItem, ParentMap, TreeData, TreeItemId } from '../types';
+import { getAllDescendantIds } from './getAllDescendantIds';
+
+const getNewItems = <T extends BasicTreeItem>(tree: TreeData<T>, itemId: TreeItemId): Record<TreeItemId, T> => {
+  // Collect all descendants to remove
+  const descendantIds = getAllDescendantIds(tree, itemId);
+  const allIdsToRemove = [itemId, ...descendantIds];
+
+  // Create new items object without removed items
+  const newItems = { ...tree.items };
+  allIdsToRemove.forEach((id) => {
+    delete newItems[id];
+  });
+  return newItems;
+};
+
+const removeFromRoot = (itemId: TreeItemId, rootIds: TreeItemId[]): TreeItemId[] | null => {
+  const newRootIds = [...rootIds];
+  const rootIndex = newRootIds.indexOf(itemId);
+  if (rootIndex === -1) {
+    logError(new Error(`[removeTreeItem] Item with id "${itemId}" not found in root`));
+    return null;
+  }
+  newRootIds.splice(rootIndex, 1);
+  return newRootIds;
+};
+
+const removeFromParent = <T extends BasicTreeItem>(
+  itemId: TreeItemId,
+  parentId: TreeItemId,
+  newItems: Record<TreeItemId, T>
+): boolean => {
+  const parent = newItems[parentId];
+  if (!parent) {
+    logError(new Error(`[removeTreeItem] Parent with id "${parentId}" not found in tree`));
+    return false;
+  }
+  newItems[parentId] = {
+    ...parent,
+    children: parent.children.filter((id) => id !== itemId),
+  };
+  return true;
+};
+
+const getNewRootIds = <T extends BasicTreeItem>(
+  itemId: TreeItemId,
+  parentMap: ParentMap,
+  tree: TreeData<T>,
+  newItems: Record<TreeItemId, T>
+): TreeItemId[] | null => {
+  const foundParentId = parentMap.get(itemId);
+
+  // Not in parentMap
+  if (foundParentId === undefined) {
+    logError(new Error(`[removeTreeItem] Item with id "${itemId}" not found in parentMap`));
+    return null;
+  }
+
+  // Remove from root
+  if (foundParentId === null) {
+    return removeFromRoot(itemId, tree.rootIds);
+  }
+
+  // Remove from parent
+  const success = removeFromParent(itemId, foundParentId, newItems);
+  return success ? [...tree.rootIds] : null;
+};
+
+/**
+ * @description Remove an item from the tree (including all descendants)
+ * @param tree - The tree to remove the item from
+ * @param itemId - The ID of the item to remove
+ * @param parentMap - Map for O(1) parent lookup performance
+ * @returns A new tree with the item and its descendants removed
+ */
+export const removeTreeItem = <T extends BasicTreeItem>({
+  tree,
+  itemId,
+  parentMap,
+}: {
+  tree: TreeData<T>;
+  itemId: TreeItemId;
+  parentMap: ParentMap;
+}): TreeData<T> => {
+  if (!tree.items[itemId]) {
+    logError(new Error(`[removeTreeItem] Item with id "${itemId}" not found in the tree`));
+    return tree;
+  }
+
+  const newItems = getNewItems(tree, itemId);
+  const newRootIds = getNewRootIds(itemId, parentMap, tree, newItems);
+
+  if (!newRootIds) {
+    return tree;
+  }
+
+  return {
+    rootIds: newRootIds,
+    items: newItems,
+  };
+};

--- a/src/examples/Tree.stories.tsx
+++ b/src/examples/Tree.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { Tree, type BasicTreeItem, type TreeData, type TreeRef } from '../HeadlessTree';
 import { Button, ControlsPanel, TreeContainer, TreeItemRenderer, type FileItem } from './ui';
 
@@ -54,7 +54,18 @@ const createTree = (): TreeData<BasicTreeItem<FileItem>> => ({
   },
 });
 
-function TreeComponent() {
+const meta: Meta<typeof Tree> = {
+  title: 'Examples/Tree',
+  component: Tree,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function DefaultTree() {
   const treeData = createTree();
   const treeRef = useRef<TreeRef<BasicTreeItem<FileItem>>>(null);
 
@@ -119,15 +130,105 @@ function TreeComponent() {
   );
 }
 
-const meta: Meta<typeof TreeComponent> = {
-  title: 'Examples/Tree',
-  component: TreeComponent,
-  parameters: {
-    layout: 'centered',
-  },
+export const Default: Story = {
+  render: () => <DefaultTree />,
 };
 
-export default meta;
-type Story = StoryObj<typeof meta>;
+function TreeWithInsertRemove() {
+  const treeData = createTree();
+  const treeRef = useRef<TreeRef<BasicTreeItem<FileItem>>>(null);
+  const [counter, setCounter] = useState(1);
 
-export const Default: Story = {};
+  const handleInsertFile = () => {
+    const newId = `new-file-${counter}`;
+    const newItem: BasicTreeItem<FileItem> = {
+      id: newId,
+      children: [],
+      customData: { name: `new-file-${counter}.ts`, type: 'file', size: 100 },
+    };
+    treeRef.current?.insertItem('1', newItem, 'last');
+    setCounter((c) => c + 1);
+  };
+
+  const handleInsertFolder = () => {
+    const newId = `new-folder-${counter}`;
+    const newItem: BasicTreeItem<FileItem> = {
+      id: newId,
+      children: [],
+      customData: { name: `new-folder-${counter}`, type: 'folder' },
+    };
+    treeRef.current?.insertItem(null, newItem, 'last');
+    setCounter((c) => c + 1);
+  };
+
+  const handleRemovePackageJson = () => {
+    treeRef.current?.removeItem('3');
+  };
+
+  const handleRemoveSrc = () => {
+    treeRef.current?.removeItem('1');
+  };
+
+  return (
+    <div
+      style={{
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+        maxWidth: '800px',
+        margin: '0 auto',
+      }}
+    >
+      <ControlsPanel>
+        <Button onClick={handleInsertFile}>Add File to src/</Button>
+        <Button onClick={handleInsertFolder} variant="secondary">
+          Add Folder to Root
+        </Button>
+        <Button onClick={handleRemovePackageJson} variant="secondary">
+          Remove package.json
+        </Button>
+        <Button onClick={handleRemoveSrc} variant="secondary">
+          Remove src/ (with children)
+        </Button>
+        <span
+          style={{
+            color: '#666',
+            fontSize: '13px',
+            fontWeight: 'normal',
+          }}
+        >
+          Insert & Remove operations
+        </span>
+      </ControlsPanel>
+
+      <TreeContainer>
+        <Tree
+          ref={treeRef}
+          initialTree={treeData}
+          options={{ syncWithInitialTree: false }}
+          renderItem={({ item, depth, toggleOpenState }) => (
+            <TreeItemRenderer
+              item={item}
+              depth={depth}
+              toggleOpenState={toggleOpenState}
+              iconType="emoji"
+              showSize={true}
+            />
+          )}
+        />
+      </TreeContainer>
+
+      <div style={{ marginTop: '16px', fontSize: '12px', color: '#666' }}>
+        <strong>Features:</strong>
+        <ul style={{ margin: '8px 0', paddingLeft: '20px' }}>
+          <li>Insert new items with insertItem(parentId, newItem, position)</li>
+          <li>Remove items with removeItem(itemId)</li>
+          <li>Removing a folder also removes all its children</li>
+          <li>Items are inserted at the specified position (first/last/before/after)</li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export const InsertAndRemove: Story = {
+  render: () => <TreeWithInsertRemove />,
+};

--- a/src/examples/Tree.stories.tsx
+++ b/src/examples/Tree.stories.tsx
@@ -1,20 +1,20 @@
-import { useRef } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Tree, type TreeRef } from '../HeadlessTree';
-import { Button, ControlsPanel, TreeContainer, TreeItemRenderer, styles } from './ui';
+import { useRef } from 'react';
+import { Tree, type BasicTreeItem, type TreeData, type TreeRef } from '../HeadlessTree';
+import { Button, ControlsPanel, TreeContainer, TreeItemRenderer, type FileItem } from './ui';
 
-const createSampleFileTree = () => ({
+const createTree = (): TreeData<BasicTreeItem<FileItem>> => ({
   rootIds: ['1', '2', '3'],
   items: {
     '1': {
       id: '1',
       children: ['1-1', '1-2', '1-3'],
-      customData: { name: 'src', type: 'folder' as const },
+      customData: { name: 'src', type: 'folder' },
     },
     '2': {
       id: '2',
       children: ['2-1', '2-2'],
-      customData: { name: 'docs', type: 'folder' as const },
+      customData: { name: 'docs', type: 'folder' },
     },
     '3': {
       id: '3',
@@ -29,7 +29,7 @@ const createSampleFileTree = () => ({
     '1-2': {
       id: '1-2',
       children: ['1-2-1'],
-      customData: { name: 'components', type: 'folder' as const },
+      customData: { name: 'components', type: 'folder' },
     },
     '1-3': {
       id: '1-3',
@@ -55,8 +55,8 @@ const createSampleFileTree = () => ({
 });
 
 function TreeComponent() {
-  const treeData = createSampleFileTree();
-  const treeRef = useRef<TreeRef<(typeof treeData.items)['1']>>(null);
+  const treeData = createTree();
+  const treeRef = useRef<TreeRef<BasicTreeItem<FileItem>>>(null);
 
   const handleExpandAll = () => {
     treeRef.current?.openAll();
@@ -67,13 +67,27 @@ function TreeComponent() {
   };
 
   return (
-    <div style={styles.container}>
+    <div
+      style={{
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+        maxWidth: '800px',
+        margin: '0 auto',
+      }}
+    >
       <ControlsPanel>
         <Button onClick={handleExpandAll}>Expand All</Button>
         <Button onClick={handleCollapseAll} variant="secondary">
           Collapse All
         </Button>
-        <span style={styles.stats}>Basic tree with programmatic controls</span>
+        <span
+          style={{
+            color: '#666',
+            fontSize: '13px',
+            fontWeight: 'normal',
+          }}
+        >
+          Basic tree with programmatic controls
+        </span>
       </ControlsPanel>
 
       <TreeContainer>

--- a/src/examples/VirtualizedTree.stories.tsx
+++ b/src/examples/VirtualizedTree.stories.tsx
@@ -1,9 +1,9 @@
-import { useRef, useState, useCallback, useEffect } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { VirtualizedTree, type VirtualizedTreeRef, type BasicTreeItem, type TreeData } from '../HeadlessTree';
-import { Button, ControlsPanel, TreeContainer, TreeItemRenderer, styles, type FileItem } from './ui';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { VirtualizedTree, type BasicTreeItem, type TreeData, type VirtualizedTreeRef } from '../HeadlessTree';
+import { Button, ControlsPanel, TreeContainer, TreeItemRenderer, type FileItem } from './ui';
 
-function generateLargeTreeData(): TreeData<BasicTreeItem<FileItem>> {
+const createTree = (): TreeData<BasicTreeItem<FileItem>> => {
   const items: Record<string, BasicTreeItem<FileItem>> = {};
   const rootIds: string[] = [];
 
@@ -75,12 +75,10 @@ function generateLargeTreeData(): TreeData<BasicTreeItem<FileItem>> {
   }
 
   return { rootIds, items };
-}
-
-// Generate data once to avoid recreation on every render
-const largeTreeData = generateLargeTreeData();
+};
 
 function VirtualizedTreeExample() {
+  const [largeTreeData] = useState(createTree);
   const treeRef = useRef<VirtualizedTreeRef<BasicTreeItem<FileItem>>>(null);
   const [stats, setStats] = useState({ visible: 0, total: 0, expanded: false });
 
@@ -93,7 +91,7 @@ function VirtualizedTreeExample() {
         expanded: virtualItems > 2000, // Rough estimate if expanded
       });
     }
-  }, []);
+  }, [largeTreeData.items]);
 
   const handleExpandAll = () => {
     treeRef.current?.openAll();
@@ -120,7 +118,13 @@ function VirtualizedTreeExample() {
   }, [updateStats]);
 
   return (
-    <div style={styles.container}>
+    <div
+      style={{
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+        maxWidth: '800px',
+        margin: '0 auto',
+      }}
+    >
       <ControlsPanel>
         <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
           <Button onClick={handleExpandAll}>Expand All</Button>
@@ -134,7 +138,14 @@ function VirtualizedTreeExample() {
           <Button onClick={handleScrollToMiddle}>Scroll to Middle</Button>
         </div>
 
-        <div style={{ ...styles.stats, marginTop: '8px', fontSize: '13px' }}>
+        <div
+          style={{
+            color: '#666',
+            fontSize: '13px',
+            fontWeight: 'normal',
+            marginTop: '8px',
+          }}
+        >
           <strong>Performance Stats:</strong> {stats.visible.toLocaleString()} visible items •{' '}
           {stats.total.toLocaleString()} total items • 10 levels deep
           {stats.expanded && <span style={{ color: '#e74c3c' }}> • High memory usage (all expanded)</span>}
@@ -148,8 +159,12 @@ function VirtualizedTreeExample() {
           height="500px"
           estimateSize={() => 32}
           overscan={10}
+          options={{
+            syncWithInitialTree: true,
+          }}
           renderItem={({ item, depth, toggleOpenState }) => (
             <div
+              key={item.id}
               style={{
                 backgroundColor: depth % 2 === 0 ? '#ffffff' : '#fafbfc',
               }}

--- a/src/examples/ui.tsx
+++ b/src/examples/ui.tsx
@@ -1,114 +1,34 @@
 import React from 'react';
 import type { BasicTreeItem } from '../HeadlessTree';
 
-// Common styles
-export const styles = {
-  container: {
-    fontFamily: 'system-ui, -apple-system, sans-serif',
-    maxWidth: '800px',
-    margin: '0 auto',
-  },
-  controlsPanel: {
-    marginBottom: '16px',
-    padding: '12px',
-    backgroundColor: '#f5f5f5',
-    borderRadius: '6px',
-    display: 'flex',
-    gap: '8px',
-    alignItems: 'center',
-    flexWrap: 'wrap' as const,
-  },
-  button: {
-    padding: '6px 12px',
-    backgroundColor: '#007acc',
-    color: 'white',
-    border: 'none',
-    borderRadius: '4px',
-    cursor: 'pointer',
-    fontSize: '14px',
-    fontWeight: '500',
-  },
-  buttonSecondary: {
-    backgroundColor: '#6c757d',
-  },
-  treeContainer: {
-    border: '1px solid #ddd',
-    borderRadius: '6px',
-    backgroundColor: 'white',
-    minHeight: '200px',
-  },
-  treeItem: {
-    display: 'flex',
-    alignItems: 'center',
-    padding: '4px 8px',
-    borderBottom: '1px solid #f0f0f0',
-    minHeight: '32px',
-    backgroundColor: 'white',
-  },
-  toggleButton: {
-    background: 'none',
-    border: 'none',
-    cursor: 'pointer',
-    fontSize: '14px',
-    marginRight: '8px',
-    padding: '4px',
-    borderRadius: '3px',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    minWidth: '20px',
-  },
-  itemContent: {
-    display: 'flex',
-    alignItems: 'center',
-    fontSize: '14px',
-    color: '#333',
-  },
-  fileSize: {
-    color: '#666',
-    fontSize: '12px',
-    marginLeft: '8px',
-  },
-  stats: {
-    color: '#666',
-    fontSize: '13px',
-    fontWeight: 'normal' as const,
-  },
-};
-
-// File/folder icons
-export const getFileIcon = (type: 'file' | 'folder', isOpened?: boolean) => {
+const getFileIcon = (type: 'file' | 'folder', isOpened?: boolean) => {
   if (type === 'folder') {
     return isOpened ? '📂' : '📁';
   }
   return '📄';
 };
 
-export const getToggleIcon = (hasChildren: boolean, isOpened?: boolean) => {
+const getToggleIcon = (hasChildren: boolean, isOpened?: boolean) => {
   if (!hasChildren) return '•';
   return isOpened ? '▼' : '▶';
 };
 
-// Common interfaces
-export interface FileItem {
-  name: string;
-  type: 'file' | 'folder';
-  size?: number;
-}
-
-// Reusable components
 export const Button: React.FC<{
   onClick: () => void;
   children: React.ReactNode;
   variant?: 'primary' | 'secondary';
-  style?: React.CSSProperties;
-}> = ({ onClick, children, variant = 'primary', style }) => (
+}> = ({ onClick, children, variant = 'primary' }) => (
   <button
     onClick={onClick}
     style={{
-      ...styles.button,
-      ...(variant === 'secondary' && styles.buttonSecondary),
-      ...style,
+      padding: '6px 12px',
+      backgroundColor: variant === 'secondary' ? '#6c757d' : '#007acc',
+      color: 'white',
+      border: 'none',
+      borderRadius: '4px',
+      cursor: 'pointer',
+      fontSize: '14px',
+      fontWeight: '500',
     }}
   >
     {children}
@@ -117,12 +37,45 @@ export const Button: React.FC<{
 
 export const ControlsPanel: React.FC<{
   children: React.ReactNode;
-}> = ({ children }) => <div style={styles.controlsPanel}>{children}</div>;
+}> = ({ children }) => (
+  <div
+    style={{
+      marginBottom: '16px',
+      padding: '12px',
+      backgroundColor: '#f5f5f5',
+      borderRadius: '6px',
+      display: 'flex',
+      gap: '8px',
+      alignItems: 'center',
+      flexWrap: 'wrap',
+    }}
+  >
+    {children}
+  </div>
+);
 
 export const TreeContainer: React.FC<{
   children: React.ReactNode;
   style?: React.CSSProperties;
-}> = ({ children, style }) => <div style={{ ...styles.treeContainer, ...style }}>{children}</div>;
+}> = ({ children, style }) => (
+  <div
+    style={{
+      border: '1px solid #ddd',
+      borderRadius: '6px',
+      backgroundColor: 'white',
+      minHeight: '200px',
+      ...style,
+    }}
+  >
+    {children}
+  </div>
+);
+
+export interface FileItem {
+  name: string;
+  type: 'file' | 'folder';
+  size?: number;
+}
 
 export const TreeItemRenderer: React.FC<{
   item: BasicTreeItem<FileItem>;
@@ -133,23 +86,55 @@ export const TreeItemRenderer: React.FC<{
 }> = ({ item, depth, toggleOpenState, showSize = true, iconType = 'emoji' }) => (
   <div
     style={{
-      ...styles.treeItem,
+      display: 'flex',
+      alignItems: 'center',
+      padding: '4px 8px',
+      borderBottom: '1px solid #f0f0f0',
+      minHeight: '32px',
+      backgroundColor: 'white',
       paddingLeft: depth * 20 + 8,
     }}
   >
     <button
       onClick={toggleOpenState}
-      style={styles.toggleButton}
+      style={{
+        background: 'none',
+        border: 'none',
+        cursor: 'pointer',
+        fontSize: '14px',
+        marginRight: '8px',
+        padding: '4px',
+        borderRadius: '3px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minWidth: '20px',
+      }}
       title={item.children.length > 0 ? (item.isOpened ? 'Collapse' : 'Expand') : 'File'}
     >
       {iconType === 'emoji'
         ? getFileIcon(item.customData.type, item.isOpened)
         : getToggleIcon(item.children.length > 0, item.isOpened)}
     </button>
-    <span style={styles.itemContent}>
+    <span
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        fontSize: '14px',
+        color: '#333',
+      }}
+    >
       {item.customData.name}
       {showSize && item.customData.size && (
-        <small style={styles.fileSize}>({item.customData.size.toLocaleString()} bytes)</small>
+        <small
+          style={{
+            color: '#666',
+            fontSize: '12px',
+            marginLeft: '8px',
+          }}
+        >
+          ({item.customData.size.toLocaleString()} bytes)
+        </small>
       )}
     </span>
   </div>


### PR DESCRIPTION
## Overview
트리 컴포넌트에 `insert`와 `remove` 기능을 추가했습니다. 사용자가 동적으로 트리 항목을 추가하고 삭제할 수 있습니다.

## 주요 변경사항

### 새로운 기능
- **`insertItem`**: 트리에 새로운 항목 삽입
  - 루트 레벨 또는 특정 부모 하위에 삽입 가능
  - 위치 지정: `first`, `last`, 숫자 인덱스, `{ before: id }`, `{ after: id }`
- **`removeItem`**: 트리에서 항목 제거 (하위 항목 모두 포함)

### 성능 최적화
- **`ParentMap`**: 부모-자식 관계를 O(1)로 조회
- **`ChildrenIndexMap`**: 자식 항목의 인덱스를 O(1)로 조회
- 대규모 트리에서도 빠른 삽입/삭제 연산 보장

### API 변경
`TreeRef` 및 `VirtualizedTreeRef`에 새로운 메서드 추가:
- `insertItem(parentId, newItem, position)`
- `removeItem(itemId)`
- `parentMap` 및 `childrenIndexMap` 접근 가능

### 코드 구조 개선
- 유틸리티 함수를 `utils/` 디렉토리로 분리
- 각 기능별 독립적인 테스트 파일 작성
- DI(Dependency Injection) 패턴 적용: 상위에서 normalize 관련 데이터 주입

## 테스트
- `insertTreeItem`: 559줄의 테스트 케이스
- `removeTreeItem`: 337줄의 테스트 케이스
- `buildParentMap`, `buildChildrenIndexMap`: 각각 100줄, 171줄의 테스트
- Edge cases 및 에러 핸들링 포함

## Storybook 예제
- 새로운 스토리 추가: `InsertAndRemove`
- 실제 사용 예제를 통한 API 검증

## Breaking Changes
없음 - 기존 API는 그대로 유지되며 새로운 기능만 추가됨