### PR TITLE
initialOpenedIds 옵션 추가

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,7 +24,7 @@ jobs:
         id: release-notes
         run: |
           VERSION="v${{ github.event.inputs.version }}"
-          
+
           # Get commits since last tag (or all commits if no previous tag)
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           if [ -z "$LAST_TAG" ]; then
@@ -32,16 +32,16 @@ jobs:
           else
             COMMITS=$(git log ${LAST_TAG}..HEAD --pretty=format:"- %s" --reverse)
           fi
-          
+
           # Create release notes
           cat > release_notes.md << EOF
           ## What's Changed
-          
+
           $COMMITS
-          
+
           **Full Changelog**: https://github.com/${{ github.repository }}/compare/${LAST_TAG}...${VERSION}
           EOF
-          
+
           echo "=== Generated Release Notes ==="
           cat release_notes.md
           echo "=== End Release Notes ==="

--- a/README.md
+++ b/README.md
@@ -225,11 +225,13 @@ const {
 ```
 
 **State Management:**
+
 - `tree` - Current tree data with merged open/close state
 - `parentMap` - Map for O(1) parent lookup performance
 - `childrenIndexMap` - Map for tracking child positions
 
 **Open/Close Operations:**
+
 - `open(id)` - Open a specific tree item
 - `close(id)` - Close a specific tree item
 - `toggleOpen(id)` - Toggle open/close state of an item
@@ -237,6 +239,7 @@ const {
 - `closeAll()` - Collapse all tree items
 
 **Tree Manipulation:**
+
 - `insertItem(parentId, newItem, position)` - Insert a new item into the tree
 - `removeItem(itemId)` - Remove an item and all its descendants
 - `moveItem(sourceId, target)` - Move an item to a new position
@@ -259,6 +262,7 @@ const isValid = canMoveItem(tree, sourceId, targetId);
 ```
 
 Validates whether a tree item can be moved to a target position. Returns `false` if:
+
 - Source and target are the same item
 - Target is a descendant of source (prevents circular references)
 
@@ -287,6 +291,7 @@ const treeRef = useRef<TreeRef<YourDataType>>(null);
 ```
 
 Provides access to:
+
 - `tree` - Current tree data
 - `parentMap` - Parent lookup map
 - `childrenIndexMap` - Children index map
@@ -306,6 +311,7 @@ const treeRef = useRef<VirtualizedTreeRef<YourDataType>>(null);
 ```
 
 Includes all TreeRef methods plus:
+
 - `virtualizer` - Access to the underlying virtualizer instance
 
 ## Advanced Usage
@@ -321,11 +327,11 @@ insertItem(parentId, newItem, 2); // Insert at index 2
 
 // Insert at predefined positions
 insertItem(parentId, newItem, 'first'); // Insert at the beginning
-insertItem(parentId, newItem, 'last');  // Insert at the end
+insertItem(parentId, newItem, 'last'); // Insert at the end
 
 // Insert relative to existing items
 insertItem(parentId, newItem, { before: 'item-id' }); // Insert before an item
-insertItem(parentId, newItem, { after: 'item-id' });  // Insert after an item
+insertItem(parentId, newItem, { after: 'item-id' }); // Insert after an item
 
 // Insert at root level (parentId = null)
 insertItem(null, newItem, 'last'); // Add to root level

--- a/src/HeadlessTree/types.ts
+++ b/src/HeadlessTree/types.ts
@@ -59,6 +59,20 @@ export interface TreeOptions {
    * However, memoization handling such as useState, useMemo, select, etc. is required for use.
    */
   syncWithInitialTree?: boolean;
+  /**
+   * Initial set of opened item IDs.
+   * If provided, this takes precedence over isOpened flags in tree items.
+   * This is useful for separating tree structure data from UI state.
+   *
+   * @example
+   * ```tsx
+   * <Tree
+   *   initialTree={treeData}
+   *   options={{ initialOpenedIds: ['1', '2', '3'] }}
+   * />
+   * ```
+   */
+  initialOpenedIds?: TreeItemId[];
 }
 
 export interface TreeProps<CustomData extends BasicTreeItem> {

--- a/src/examples/DndTree.stories.tsx
+++ b/src/examples/DndTree.stories.tsx
@@ -166,7 +166,8 @@ export const DeepNesting: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'A deeply nested tree structure to test drag and drop with multiple nesting levels and complex hierarchies.',
+        story:
+          'A deeply nested tree structure to test drag and drop with multiple nesting levels and complex hierarchies.',
       },
     },
   },

--- a/src/examples/DndTree.tsx
+++ b/src/examples/DndTree.tsx
@@ -135,9 +135,7 @@ const DndTreeItem: React.FC<DndTreeItemProps> = ({
 
       <div
         style={
-          showIndicator && dropPosition === 'inside'
-            ? DROP_INSIDE_STYLE
-            : { transition: 'background-color 0.15s' }
+          showIndicator && dropPosition === 'inside' ? DROP_INSIDE_STYLE : { transition: 'background-color 0.15s' }
         }
       >
         <TreeItemRenderer
@@ -201,7 +199,11 @@ export const DndTree: React.FC<DndTreeProps> = ({ initialTree }) => {
     });
   };
 
-  const getTargetIndex = (tree: TreeData<BasicTreeItem<FileItem>>, targetId: TreeItemId, parentId: TreeItemId | null | undefined): number => {
+  const getTargetIndex = (
+    tree: TreeData<BasicTreeItem<FileItem>>,
+    targetId: TreeItemId,
+    parentId: TreeItemId | null | undefined
+  ): number => {
     if (parentId !== null && parentId !== undefined) {
       const parent = tree.items[parentId];
       return parent.children.indexOf(targetId);


### PR DESCRIPTION
기존에는 initialTree로만 관리했는데 사용자에 따라 openedIds를 따로 관리하는 경우도 있을 것 같아서 인터페이스 추가